### PR TITLE
Fix: auth process no longer matches Observable and Github

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "git://github.com/mootari/observable-client.git"
   },
   "dependencies": {
+    "cheerio": "^1.0.0-rc.3",
     "prompts": "^2.0.3",
     "superagent": "^4.1.0"
   }

--- a/readme.md
+++ b/readme.md
@@ -10,18 +10,6 @@ A set of tools to communicate with observablehq.com:
 npm install mootari/observable-client
 ```
 
-## Authentication
-
-### GitHub
-
-Authentication against GitHub requires you to provide Observable's client ID. To obtain the ID follow these steps:
-1. Open a private window (or log out of GitHub)
-2. Visit [observablehq.com](https://beta.observablehq.com/).
-3. Click "Sign in" and select "Sign in with GitHub".
-4. From the URL you were redirected to copy the part after `?client_id=`, up to (but excluding) the next `&`.
-
-The client ID should be 20 characters long and only contain the characters 0-9 and a-f.  
-
 #### Example
 
 ```js
@@ -30,8 +18,8 @@ const {RestClient, AuthGithubPrompt} = require('observable-client');
 const client = new RestClient;
 (async () => {
   await new AuthGithubPrompt(client, {
-    clientId: '0123456789abcdef0123',
     loginName: 'username',
+    loginPass: 'password', // Optional. Will be prompted if not provided here.
   }).authorize();
 
   console.log('authorized', (await client.get('/user')).body);

--- a/src/lib/auth/github-prompt.js
+++ b/src/lib/auth/github-prompt.js
@@ -30,11 +30,19 @@ module.exports = class GitHubPrompt extends GitHub {
   }
 
   async get2FAToken() {
-    const token = (await prompts({
+    return (await prompts({
       type: 'text',
       name: 'value',
       message: 'GitHub 2FA Token',
     })).value;
-    return token;
   }
+
+  async getDeviceVerificationCode() {
+    return (await prompts({
+      type: 'text',
+      name: 'value',
+      message: 'GitHub device verification code',
+    })).value;
+  }
+
 };

--- a/src/lib/auth/github.js
+++ b/src/lib/auth/github.js
@@ -1,59 +1,72 @@
 'use strict';
 
+const cheerio = require('cheerio');
+
 module.exports = class GitHub {
   constructor(client, options = {}) {
-    const {clientId, loginName, loginPass} = options;
-
-    if(typeof clientId !== 'string' || !clientId.match(/[a-f0-9]{20}/)) {
-      throw Error('Invalid Github client ID');
-    }
+    const {loginName, loginPass} = options;
 
     this.client = client;
-    this.clientId = clientId;
     this.loginName = loginName;
     this.loginPass = loginPass;
     this.maxAttempts = 1;
   }
 
   async authorize() {
-    const {agent, SITE_URL, API_URL} = this.client;
-    this.client.ensureToken();
+    const {SITE_URL} = this.client;
     const redirectPath = '/';
+    const submit = (url, data) => this.client.agent.post(url)
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(data);
 
-    let step = await agent.get('https://github.com/login/oauth/authorize').query({
-      client_id: this.clientId,
-      state: this.client.getToken(),
-      redirect_uri: `${API_URL}/github/oauth?path=${encodeURIComponent(redirectPath)}`,
+    // Observable: Login
+    this.client.ensureToken();
+    let step = await this.client.post('/login', {
+      token: this.client.getToken(),
+      path: redirectPath,
+      login: this.loginName,
     });
 
     if(!this.matchUrl(step, 'https://github.com/login')) {
       throw Error('Unexpected entry point');
     }
 
+    // Github: Enter credentials
     let attempts = this.maxAttempts;
     while(this.matchUrl(step, 'https://github.com/login')) {
       if(attempts-- <= 0) throw Error('Too many attempts');
 
       const [name, pass] = await this.getCredentials();
-      step = await agent.post('https://github.com/session')
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({
-          authenticity_token: this.extractAuthToken(step.text),
-          login: name,
-          password: pass,
-        });
+      const data = {
+        ...this.getFormData(step),
+        login: name,
+        password: pass,
+      };
+      step = await submit('https://github.com/session', data);
     }
 
+    // Github: Enter 2FA token
     attempts = this.maxAttempts;
     while(this.matchUrl(step, 'https://github.com/sessions/two-factor')) {
       if(attempts-- <= 0) throw Error('Too many attempts');
 
-      step = await agent.post(step.request.url)
-        .set('Content-Type', 'application/x-www-form-urlencoded')
-        .send({
-          authenticity_token: this.extractAuthToken(step.text),
-          otp: await this.get2FAToken(),
-        });
+      const data = {
+        ...this.getFormData(step),
+        otp: await this.get2FAToken(),
+      };
+      step = await submit(step.request.url, data);
+    }
+
+    // Github: Enter device verification code
+    attempts = this.maxAttempts;
+    while(this.matchUrl(step, 'https://github.com/sessions/verified-device')) {
+      if(attempts-- <= 0) throw Error('Too many attempts');
+
+      const data = {
+        ...this.getFormData(step),
+        otp: await this.getDeviceVerificationCode(),
+      };
+      step = await submit('https://github.com/sessions/verified-device', data);
     }
 
     if(!this.matchUrl(step, SITE_URL + redirectPath)) {
@@ -71,9 +84,14 @@ module.exports = class GitHub {
     throw Error('Non-interactive authenticator does not support 2FA');
   }
 
-  extractAuthToken(text) {
-    const m = text.match(/ name="authenticity_token" value="([^"]+)"/);
-    return m ? m[1] : null;
+  async getDeviceVerificationCode() {
+    // pattern="([0-9]{6})|([0-9a-fA-F]{5}-?[0-9a-fA-F]{5})"
+    throw Error('Non-interactive authenticator does not support device verification');
+  }
+
+  getFormData(response) {
+    const data = cheerio.load(response.text)('form').first().serializeArray();
+    return Object.fromEntries(data.map(({name, value}) => [name, value]));
   }
 
   matchUrl(response, path) {

--- a/src/lib/client/rest.js
+++ b/src/lib/client/rest.js
@@ -48,12 +48,7 @@ module.exports = class RestClient {
       else throw Error(`Request method "${method}" does not allow data.`);
     }
 
-    try {
-      return (await req);
-    } catch (e) {
-      // todo: throw?
-      return null;
-    }
+    return req;
   }
 
   /**


### PR DESCRIPTION
- Observable has split up its login flow: the first step now only requests the login name, after which a redirect to the user's external auth service (e.g. github) is issued.
- Github has ramped up its security measures: since July 2019 each new device must be verified if 2FA is disabled ([announcement](https://github.blog/changelog/2019-07-01-verified-devices); user feedback: [1](https://github.community/t/opt-out-of-user-device-verification-requested/2175), [2](https://github.community/t/disable-remove-email-device-verification-prompt-on-login-not-the-2fa/2333)).
- This PR introduces a dependency to [cheerio](https://github.com/cheeriojs/cheerio), which is used to retrieve the actual form data from each page.
- It also adds a prompt for the device token, but verification currently fails with an HTTP 422 error. 2FA might just work (couldn't test myself).

Fixes #2 